### PR TITLE
Opaleye Enum

### DIFF
--- a/composite-opaleye/composite-opaleye.cabal
+++ b/composite-opaleye/composite-opaleye.cabal
@@ -55,6 +55,7 @@ library
     , postgresql-simple >=0.5.3.0 && <0.7
     , product-profunctors >=0.8.0.3 && <0.12
     , profunctors >=5.2.1 && <5.7
+    , split >= 0.2.3 && < 0.3
     , template-haskell >=2.11.1.0 && <2.19
     , text >=1.2.2.2 && <1.3
     , vinyl >=0.5.3 && <0.15


### PR DESCRIPTION
When deserializing postgres types, compare only the type name instead of the schema. The documentation said this was a feature, but it was inconsistent with the implementation.

So now, regardless of PG version or schema-qualified type, we should be only comparing the unqualified type names.