### PR TITLE
composite-aeson: use SuccessOrFail pure to define return

### DIFF
--- a/composite-aeson/src/Composite/Aeson/Formats/DateTime.hs
+++ b/composite-aeson/src/Composite/Aeson/Formats/DateTime.hs
@@ -93,7 +93,7 @@ instance Applicative SuccessOrFail where
   Fail    f <*> _         = Fail    f
 
 instance Monad SuccessOrFail where
-  return = Success
+  return = pure
   Success a >>= k = k a
   Fail    f >>= _ = Fail f
 #if MIN_VERSION_base(4,13,0)


### PR DESCRIPTION
Avoid triggering a warning for [non-canonical Monad instances](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0314-warn-noncanonical-monad-instance-by-default.rst) on newer GHC compilers.

Changes test on GHC 8.10.7 and GHC 9.2.3 ✅ 