### PR TITLE
Allow using FieldNullable

### DIFF
--- a/composite-opaleye/src/Composite/Opaleye/RecordTable.hs
+++ b/composite-opaleye/src/Composite/Opaleye/RecordTable.hs
@@ -9,7 +9,7 @@ import qualified Data.Profunctor.Product as PP
 import Data.Proxy (Proxy(Proxy))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 #if MIN_VERSION_opaleye(0,8,0)
-import Opaleye (Field, requiredTableField, optionalTableField)
+import Opaleye (Field_, requiredTableField, optionalTableField)
 import Opaleye.Internal.Table (TableFields)
 #else
 import Opaleye (Column, required, optional)

--- a/composite-opaleye/src/Composite/Opaleye/RecordTable.hs
+++ b/composite-opaleye/src/Composite/Opaleye/RecordTable.hs
@@ -24,10 +24,10 @@ import Opaleye.Internal.Table (TableProperties)
 class DefaultRecTableField write read where
   defaultRecTableField :: String -> TableFields write read
 
-instance DefaultRecTableField (Maybe (Field a)) (Field a) where
+instance DefaultRecTableField (Maybe (Field_ n a)) (Field_ n a) where
   defaultRecTableField = optionalTableField
 
-instance DefaultRecTableField (Field a) (Field a) where
+instance DefaultRecTableField (Field_ n a) (Field_ n a) where
   defaultRecTableField = requiredTableField
 #else
 -- |Helper typeclass which picks which of 'required' or 'optional' to use for a pair of write column type and read column type.


### PR DESCRIPTION
The `Column` included both Nullable and NonNullable fields, whereas `Field` is a `Field_ 'NonNullable` only. This is needed to allow tables that use FieldNullable. 